### PR TITLE
Fix Typo in `Layout/AssignmentIndentation` cop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -7,7 +7,7 @@ Layout/ArgumentAlignment:
 Layout/ArrayAlignment:
   Enabled: false
 
-Layout/AssingmentIndentation:
+Layout/AssignmentIndentation:
   Enabled: false
 
 Layout/BlockAlignment:


### PR DESCRIPTION
Hey thanks for this Gem!

My Rubocop complained about an unrecognized cop though, which turned out to be a typo :-)