### PR TITLE
Fix namespace for LineLength in rubocop.yml

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -248,7 +248,7 @@ Layout/Tab:
 Layout/TrailingEmptyLines:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Layout/TrailingWhitespace:


### PR DESCRIPTION
Thanks for this gem!

I got the following message when running rubocop: `Metrics/LineLength has the wrong namespace - should be Layout`. I have renamed 'Metrics/LineLength' to 'Layout/LineLength' (see [rubocop source](https://github.com/rubocop-hq/rubocop/blob/cca6e8ff8d30ca8048165fe8cd545567f91c3edb/config/default.yml#L805)).