### PR TITLE
Fix typo in cop name

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -7,7 +7,7 @@ Layout/ArgumentAlignment:
 Layout/ArrayAlignment:
   Enabled: false
 
-Layout/AssingmentIndentation:
+Layout/AssignmentIndentation:
   Enabled: false
 
 Layout/BlockAlignment:


### PR DESCRIPTION
The cop Layout/Assi**gn**mentIndentation is miss typed as Layout/Assi**ng**mentIndentation.