### PR TITLE
Update rule name to the renamed Layout/IndentFirstArgument

### DIFF
--- a/config/awesomecode-rubocop.yml
+++ b/config/awesomecode-rubocop.yml
@@ -108,7 +108,7 @@ Layout/FirstMethodArgumentLineBreak:
 Layout/FirstMethodParameterLineBreak:
   Enabled: false
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: false
 
 # Layout/HeredocArgumentClosingParenthesis

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -106,7 +106,7 @@ Layout/FirstMethodArgumentLineBreak:
 Layout/FirstMethodParameterLineBreak:
   Enabled: false
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: false
 
 # Layout/HeredocArgumentClosingParenthesis


### PR DESCRIPTION
Rubocop 0.68 renames `Layout/FirstParameterIndentation` to `Layout/IndentFirstArgument`.

This PR updates the name to the new one in every config in this project.