### PR TITLE
rename cop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -106,7 +106,7 @@ Layout/FirstMethodArgumentLineBreak:
 Layout/FirstMethodParameterLineBreak:
   Enabled: false
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: false
 
 # Layout/HeredocArgumentClosingParenthesis


### PR DESCRIPTION
The `Layout/IndentFirstArgument` cop has been renamed to `Layout/FirstArgumentIndentation`.